### PR TITLE
fix: made the stress map 90% of the screen width so that it is easier to scroll past it on the site

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -16,7 +16,7 @@
 #map-container {
   max-height: 90%;
   height: 800px;
-  /* width: 80%; */
+   width: 90%; 
   margin: auto;
   /* temporarily set the background color so we can tell where the map container is positioned */
   background-color: lightgrey;


### PR DESCRIPTION
When the map covers 100% of the width of the site, it is hard to scroll past it on desktop as well as on mobile. This can be a frustrating user experience. I reduced its size to 90% of the screen width.

The map can also still be fullscreened using the four arrow button in the top right of the map, so if the user does want it to take up their entire screen, they still have that option.

## Before: 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/2854cf17-5b69-4e52-b3b1-0de8deed6cd0" />


## After: 
<img width="1440" alt="image" src="https://github.com/user-attachments/assets/b0317ffa-863b-43b9-b8c9-1dea5be9e145" />
